### PR TITLE
Minimum version for sqlite

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ Here I make a type error on purpose inputting `string` instead of an `integer`.
 
 ## Install
 
-**Minimum version**: python:`3.8.2`, nvim: `0.5`
+**Minimum version**: python:`3.8.2`, nvim: `0.5`, sqlite `3.31.0`
 
 Install the usual way, ie. VimPlug, Vundle, etc
 


### PR DESCRIPTION
When first trying out coq, I had problems setting it up as the minimum sqlite version that supports generated columns (which coq uses) is 3.31.0, which depending on the system being used, may or may not be the version included in your python3 installation. 

For posterity, I'll leave here the solution to the problem:

- System state
    - **OS:** MacOS Catalina
    - Homebrew 3.2.6
- Steps to fix:
    - Update sqlite3 to `>=3.31.0`. Example: `brew upgrade sqlite3`
    - Install python with the compile flags `LD_RUN_PATH=/usr/local/opt/sqlite/lib LDFLAGS=-L/usr/local/opt/sqlite/lib CPPFLAGS=-I/usr/local/include`. If you're using pyenv, here's is an example: `PYTHON_CONFIGURE_OPTS="LD_RUN_PATH=/usr/local/opt/sqlite/lib LDFLAGS=-L/usr/local/opt/sqlite/lib CPPFLAGS=-I/usr/local/include" pyenv install 3.9.6`
    - You may have to update the `PATH` variable to include brew's `sqlite3` before the system one.

Thank you for the awesome tool 👏 