### PR TITLE
Resolve executable and runtime dir when comparing

### DIFF
--- a/coq/__main__.py
+++ b/coq/__main__.py
@@ -45,7 +45,7 @@ _LOCK_FILE = RT_DIR / "requirements.lock"
 _EXEC_PATH = Path(executable)
 _REQ = REQUIREMENTS.read_text()
 
-_IN_VENV = _EXEC_PATH == RT_PY
+_IN_VENV = RT_PY.is_file() and RT_PY.samefile(_EXEC_PATH)
 
 
 if command == "deps":


### PR DESCRIPTION
I encountered an issue when trying to use this plugin with symlinks. I use `vim-plug` and a dotfiles repo, so my setup is

`~/dotfiles/vim/plugged/coq_nvim/...`
`~/.config/nvim` -> `~/dotfiles/vim`

This causes `coq run` not to work, because `RT_PY` resolves to the dotfiles link, and executable resolves to the `.config` link (or vice versa, I forget), so `_IN_VENV` ends up being false. Using `Path.samefile` resolves them until there are no more symlinks. The extra `is_file` is required so that it doesn't throw an exception before the `.vars` directory has been created. 