### PR TITLE
End completion mode if there are no matches

### DIFF
--- a/coq/server/nvim/completions.py
+++ b/coq/server/nvim/completions.py
@@ -48,7 +48,11 @@ _LUA = """
   vim.schedule(function()
     local mode = vim.api.nvim_get_mode().mode
     if mode == "i" or mode == "ic" or mode == "ix" then
-      vim.fn.complete(col, items)
+      if #items ~= 0 then
+        vim.fn.complete(col, items)
+      elseif mode == "ic" then
+        vim.api.nvim_feedkeys(vim.api.nvim_replace_termcodes("<C-e>", true, true, true), "n", true)
+      end
     end
   end)
 end)(...)


### PR DESCRIPTION
This reduces calls to `complete()`: If there are no matches, end completion mode if currently in completion mode, otherwise don't do anything. Also makes it easier for someone to press `CTRL-E` continuously to insert the characters below the cursor (although I don't think anyone uses this feature).