### PR TITLE
WIP: User-defined snippets

### DIFF
--- a/config/defaults.yml
+++ b/config/defaults.yml
@@ -109,7 +109,8 @@ clients:
     enabled: True
     short_name: "SNIP"
     weight_adjust: 0
-    sources: []
+    compiled_sources: []
+    load_from: "user_defined_snippets"
 
   tags:
     enabled: True

--- a/coq/shared/settings.py
+++ b/coq/shared/settings.py
@@ -132,7 +132,8 @@ class TSClient(BaseClient):
 
 @dataclass(frozen=True)
 class SnippetClient(BaseClient):
-    sources: AbstractSet[str]
+    compiled_sources: AbstractSet[str]
+    load_from: Literal['compiled_sources', 'user_defined_snippets']
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
Hey @ms-jpq .

I know you said [here](https://github.com/ms-jpq/coq_nvim/issues/10#issuecomment-898900522) that user defined snippets will be part of version 1.1 (btw, what version are we at currently?), but I couldn't wait 😂 .

There's no tests and no docs in this PR. I wanted to get feedback before doing more. Here's how the PR works:

1. Users can add their own snippets anywhwere under a directory in `runtimepath` that is named one of `neosnippets`, `snippets`, or `UltiSnips`. 
2. Snippets under `neosnippets` get parsed by `coq.snippets.loaders.neosnippet.parse`, and snippets under `snippets` and `UltiSnips` are pased by `coq.snippets.loaders.ultisnips.parse`. ¹ The directory naming follows convention established by the `neosnippet.vim`, `UltiSnips`, and `vim-snipmate` plugins.
3. There's a setting `clients.snippets.load_from`, which can be set to either `"user_defined_snippets"`, or `"compiled_sources"`. Setting it to the latter would make coq load `coq+snippets.json` files as usual.

Soo, is this PR a step in the right direction? Particualrly, I find the `clients.snippets.load_from` setting unintuitive. I think if user-defined snippets are included, coq.artifacts should be changed to have the structure of "just another set of directories of user-defined snippets", instead of everything being compiled to one JSON.


<hr>

¹I _believe_ that UltiSnips syntax is a superset of snipMate. I think this codebase uses `"snu"` to denote this syntax.
