### PR TITLE
Use extmarks to determine inserted text and redo cursor movement

### DIFF
--- a/coq/snippets/loaders/load.py
+++ b/coq/snippets/loaders/load.py
@@ -50,7 +50,9 @@ def load(
             for label, sp in spec.items():
                 for ext, path in sp:
                     with path.open(encoding="UTF-8") as fd:
-                        parsed = parser(path, enumerate(fd, start=1))
+                        parsed = parser(
+                            path, enumerate((line.rstrip() for line in fd), start=1)
+                        )
                     yield label, ext, *parsed
 
     meta: MutableMapping[


### PR DESCRIPTION
Much faster than `trans_inplace` in a very long line. Cursor movement is redone only if it is inside the inserted text. Otherwise (if the cursor is somehow moved to another line) the cursor is always moved to the end of the inserted text.