### PR TITLE
fix(lsp): correctly detect handler api

### DIFF
--- a/coq/lsp/requests/completion.lua
+++ b/coq/lsp/requests/completion.lua
@@ -37,7 +37,7 @@
       end
 
       local on_resp = function(...)
-        if type(({...})[4]) == "table" then
+        if type(({...})[2]) ~= "string" then
           on_resp_new(...)
         else
           on_resp_old(...)


### PR DESCRIPTION
The config argument to lsp handlers can be nil so the current doesn't work and totally breaks the lsp source. Changed to check if the second argument is a string which is the method in the case of the old API :smile:  