### PR TITLE
Add COQmarks_available() to check if there are marks available

### DIFF
--- a/coq/server/registrants/marks.py
+++ b/coq/server/registrants/marks.py
@@ -138,3 +138,11 @@ def nav_mark(nvim: Nvim, stack: Stack) -> None:
     else:
         msg = LANG("no more marks")
         write(nvim, msg)
+
+
+@rpc(blocking=True)
+def marks_available(nvim: Nvim, stack: Stack) -> bool:
+    ns = create_ns(nvim, ns=NS)
+    win = cur_win(nvim)
+    buf = win_get_buf(nvim, win=win)
+    return bool(nvim.api.buf_get_extmarks(buf, ns, 0, -1, {"limit": 1}))


### PR DESCRIPTION
This is created because of #242.

I used `{"limit": 1}` for (negligibly?) better performance. Not sure if this is necessary.