### PR TITLE
Use "combine" instead of "blend" as ghost text hl_mode

### DIFF
--- a/coq/server/registrants/preview.py
+++ b/coq/server/registrants/preview.py
@@ -328,7 +328,7 @@ def _virt_text(nvim: Nvim, ghost: GhostText, text: str) -> None:
             end=(row, 0),
             meta={
                 "virt_text_pos": "overlay",
-                "hl_mode": "blend",
+                "hl_mode": "combine",
                 "virt_text_win_col": col,
                 "virt_text": ((virt_text, ghost.highlight_group),),
             },


### PR DESCRIPTION
Using "combine" make "CursorLine" apply to ghost text. (<https://github.com/neovim/neovim/issues/15485>)