### PR TITLE
Implement all of VS code variables in snippets

### DIFF
--- a/.github/.agp
+++ b/.github/.agp
@@ -3,4 +3,4 @@ Auto Github Push (AGP)
 https://github.com/ms-jpq/auto-github-push
 
 ---
-2021-09-17 00:33
+2021-09-18 00:28

--- a/coq/clients/tags/worker.py
+++ b/coq/clients/tags/worker.py
@@ -53,7 +53,16 @@ async def _mtimes(paths: AbstractSet[str]) -> Mapping[str, float]:
 
 def _doc(client: TagsClient, context: Context, tag: Tag) -> Doc:
     def cont() -> Iterator[str]:
-        lc, rc = context.comment
+        if context.comment_strings.block:
+            lc, rc = (
+                context.comment_strings.block.start,
+                context.comment_strings.block.end,
+            )
+        elif context.comment_strings.line:
+            lc, rc = context.comment_strings.line, ""
+        else:
+            lc, rc = "", ""
+
         path, cfn = PurePath(tag["path"]), PurePath(context.filename)
         if path == cfn:
             pos = "."

--- a/coq/clients/tree_sitter/worker.py
+++ b/coq/clients/tree_sitter/worker.py
@@ -12,7 +12,15 @@ from ...treesitter.types import Payload
 
 
 def _doc(client: TSClient, context: Context, payload: Payload) -> Optional[Doc]:
-    clhs, crhs = context.comment
+    if context.comment_strings.block:
+        clhs, crhs = (
+            context.comment_strings.block.start,
+            context.comment_strings.block.end,
+        )
+    elif context.comment_strings.line:
+        clhs, crhs = context.comment_strings.line, ""
+    else:
+        clhs, crhs = "", ""
 
     def cont() -> Iterator[str]:
         if payload.grandparent:

--- a/coq/server/context.py
+++ b/coq/server/context.py
@@ -6,7 +6,8 @@ from typing import Literal, Tuple, cast
 
 from pynvim import Nvim
 from pynvim.api import Buffer
-from pynvim_pp.api import LFfmt, buf_get_lines
+from pynvim_pp.api import LFfmt, buf_get_lines, getreg
+from pynvim_pp.comment import get_comment_strings
 from pynvim_pp.atomic import Atomic
 from pynvim_pp.lib import decode, encode
 from pynvim_pp.text_object import gen_split
@@ -42,7 +43,6 @@ def context(
     buf_line_count = ns.line_count
     filename = normcase(cast(str, ns.name))
     filetype = cast(str, ns.filetype)
-    comment_str = cast(str, ns.commentstring)
     tabstop = ns.tabstop
     expandtab = cast(bool, ns.expandtab)
     linefeed = cast(Literal["\n", "\r", "\r\n"], LFfmt[cast(str, ns.fileformat)].value)
@@ -70,7 +70,7 @@ def context(
     line = lines[r]
     lines_before, lines_after = lines[:r], lines[r + 1 :]
 
-    lhs, _, rhs = comment_str.partition("%s")
+    comment_strings = get_comment_strings(nvim)
     b_line = encode(line)
     before, after = decode(b_line[:col]), decode(b_line[col:])
     split = gen_split(lhs=before, rhs=after, unifying_chars=options.unifying_chars)
@@ -78,6 +78,8 @@ def context(
         reversed(tuple(takewhile(lambda c: c.isspace(), reversed(before))))
     )
     ws_after = "".join(takewhile(lambda c: c.isspace(), after))
+
+    clipboard = getreg(nvim, "+")
 
     ctx = Context(
         manual=manual,
@@ -91,7 +93,7 @@ def context(
         linefeed=linefeed,
         tabstop=tabstop,
         expandtab=expandtab,
-        comment=(lhs, rhs),
+        comment_strings=comment_strings,
         position=pos,
         scr_col=scr_col,
         line=split.lhs + split.rhs,
@@ -108,5 +110,6 @@ def context(
         syms_after=split.syms_rhs,
         ws_before=ws_before,
         ws_after=ws_after,
+        clipboard=clipboard
     )
     return ctx

--- a/coq/shared/context.py
+++ b/coq/shared/context.py
@@ -3,6 +3,8 @@ from pathlib import Path, PurePath
 from typing import AbstractSet
 from uuid import uuid4
 
+from pynvim_pp.comment import CommentStrings
+
 from .parse import is_word
 from .parse import lower as _lower
 from .types import Context
@@ -21,7 +23,7 @@ EMPTY_CONTEXT = Context(
     linefeed="\n",
     tabstop=2,
     expandtab=True,
-    comment=("", ""),
+    comment_strings=CommentStrings(None, None),
     position=(0, 0),
     scr_col=0,
     line="",
@@ -38,6 +40,7 @@ EMPTY_CONTEXT = Context(
     syms_after="",
     ws_before="",
     ws_after="",
+    clipboard=None
 )
 
 

--- a/coq/shared/types.py
+++ b/coq/shared/types.py
@@ -1,8 +1,10 @@
 from dataclasses import dataclass, field
 from enum import Enum, auto
 from pathlib import PurePath
-from typing import Any, Literal, Optional, Sequence, Tuple, Union
+from typing import Any, Literal, Optional, Sequence, Tuple
 from uuid import UUID, uuid4
+
+from pynvim_pp.comment import CommentStrings
 
 UTF8: Literal["UTF-8"] = "UTF-8"
 UTF16: Literal["UTF-16-LE"] = "UTF-16-LE"
@@ -41,7 +43,7 @@ class Context:
     linefeed: Literal["\r\n", "\n", "\r"]
     tabstop: int
     expandtab: bool
-    comment: Tuple[str, str]
+    comment_strings: CommentStrings
 
     position: NvimPos
     scr_col: int
@@ -64,6 +66,8 @@ class Context:
 
     ws_before: str
     ws_after: str
+
+    clipboard: Optional[str]
 
 
 @dataclass(frozen=True)

--- a/coq/snippets/parsers/lsp.py
+++ b/coq/snippets/parsers/lsp.py
@@ -1,7 +1,10 @@
+from datetime import datetime
 from pathlib import PurePath
 from re import RegexFlag, compile
 from re import error as RegexError
+from random import Random
 from string import ascii_letters, digits
+from uuid import uuid4
 from typing import (
     AbstractSet,
     Callable,
@@ -68,6 +71,8 @@ _RE_FLAGS = {
     "s": RegexFlag.DOTALL,
 }
 _REGEX_FLAG_CHARS = {*_RE_FLAGS, "g", "u"}
+RANDOM = Random()
+HEXDIGITS = digits + "ABCDEF"
 
 
 def _parse_escape(context: ParserCtx, *, escapable_chars: AbstractSet[str]) -> str:
@@ -181,6 +186,78 @@ def _variable_substitution(context: ParserCtx, *, var_name: str) -> Optional[str
 
     elif var_name == "TM_FILEPATH":
         return str(path)
+
+    elif var_name == "RELATIVE_FILEPATH":
+        try:
+            return str(path.relative_to(ctx.cwd))
+        except ValueError:
+            return None
+
+    elif var_name == "CLIPBOARD":
+        return ctx.clipboard
+
+    elif var_name == "WORKSPACE_NAME":
+        return ctx.cwd.name
+
+    elif var_name == "WORKSPACE_FOLDER":
+        return str(ctx.cwd)
+
+    # Randomv value related
+    elif var_name == "RANDOM":
+        return "".join(RANDOM.choices(digits, k=6))
+
+    elif var_name == "RANDOM_HEX":
+        return "".join(RANDOM.choices(HEXDIGITS, k=6))
+
+    elif var_name == "UUID":
+        return str(uuid4())
+
+    # Date/time related
+    elif var_name == "CURRENT_YEAR":
+        return datetime.now().strftime("%Y")
+
+    elif var_name == "CURRENT_YEAR_SHORT":
+        return datetime.now().strftime("%y")
+
+    elif var_name == "CURRENT_MONTH":
+        return datetime.now().strftime("%m")
+
+    elif var_name == "CURRENT_MONTH_NAME":
+        return datetime.now().strftime("%B")
+
+    elif var_name == "CURRENT_MONTH_NAME_SHORT":
+        return datetime.now().strftime("%b")
+
+    elif var_name == "CURRENT_DATE":
+        return datetime.now().strftime("%d")
+
+    elif var_name == "CURRENT_DAY_NAME":
+        return datetime.now().strftime("%A")
+
+    elif var_name == "CURRENT_DAY_NAME_SHORT":
+        return datetime.now().strftime("%a")
+
+    elif var_name == "CURRENT_HOUR":
+        return datetime.now().strftime("%H")
+
+    elif var_name == "CURRENT_MINUTE":
+        return datetime.now().strftime("%M")
+
+    elif var_name == "CURRENT_SECOND":
+        return datetime.now().strftime("%S")
+
+    elif var_name == "CURRENT_SECONDS_UNIX":
+        return str(round(datetime.now().timestamp()))
+
+    # Inserting line or block comments
+    elif var_name == "BLOCK_COMMENT_START":
+        return ctx.comment_strings.block.start if ctx.comment_strings.block else ""
+
+    elif var_name == "BLOCK_COMMENT_END":
+        return ctx.comment_strings.block.end if ctx.comment_strings.block else ""
+
+    elif var_name == "LINE_COMMENT":
+        return ctx.comment_strings.line or ""
 
     else:
         return None


### PR DESCRIPTION
Hey @ms-jpq , I thought it would be a good idea to implement [VS Code's snippet variables](https://code.visualstudio.com/docs/editor/userdefinedsnippets#_variables) (which are a superset of the LSP specification's). I noticed only after I finished that [you don't have the bandwidth  to maintain a superset of the LSP snippet grammar.](https://github.com/ms-jpq/coq_nvim/issues/247#issuecomment-915526512) . Arguably, this PR is not a change in the grammar 😆 . But yeah, it's totally cool if this is beyond the scope of the project, since there's so many moving parts already.

PS: In the unlikely case that you are planning on implementing arbitrary code execution during snippet expansion (like [LuaSnip](https://github.com/L3MON4D3/LuaSnip/blob/ccf8d5da2370877ccf7b3ea164d0530ff1f59a87/doc/luasnip.txt#L188), or [UltiSnips](https://github.com/SirVer/ultisnips/blob/53e1921e3ef015ef658e540c0aa9c4835f9c18a6/doc/UltiSnips.txt#L820)) at some point, I would imagine that this PR shouldn't get merged since all the variables are basically python one liners behind the scenes.