### PR TITLE
Respect pumwidth when truncating

### DIFF
--- a/.github/.agp
+++ b/.github/.agp
@@ -3,4 +3,4 @@ Auto Github Push (AGP)
 https://github.com/ms-jpq/auto-github-push
 
 ---
-2021-10-05 00:31
+2021-10-06 00:32

--- a/.github/.agp
+++ b/.github/.agp
@@ -3,4 +3,4 @@ Auto Github Push (AGP)
 https://github.com/ms-jpq/auto-github-push
 
 ---
-2021-10-04 00:35
+2021-10-05 00:31

--- a/.github/.agp
+++ b/.github/.agp
@@ -3,4 +3,4 @@ Auto Github Push (AGP)
 https://github.com/ms-jpq/auto-github-push
 
 ---
-2021-10-06 00:32
+2021-10-07 00:32

--- a/.github/.agp
+++ b/.github/.agp
@@ -3,4 +3,4 @@ Auto Github Push (AGP)
 https://github.com/ms-jpq/auto-github-push
 
 ---
-2021-10-03 00:33
+2021-10-04 00:35

--- a/coq/server/context.py
+++ b/coq/server/context.py
@@ -23,6 +23,7 @@ def context(
 ) -> Context:
     with Atomic() as (atomic, ns):
         ns.scr_col = atomic.call_function("screencol", ())
+        ns.pumwidth = atomic.get_option("pumwidth")
         ns.buf = atomic.get_current_buf()
         ns.name = atomic.buf_get_name(0)
         ns.line_count = atomic.buf_line_count(0)
@@ -35,6 +36,7 @@ def context(
         atomic.commit(nvim)
 
     scr_col = ns.scr_col
+    pumwidth = ns.pumwidth
     buf = cast(Buffer, ns.buf)
     (r, col) = cast(Tuple[int, int], ns.cursor)
     row = r - 1
@@ -89,6 +91,7 @@ def context(
         expandtab=expandtab,
         comment=(lhs, rhs),
         position=pos,
+        pumwidth=pumwidth,
         scr_col=scr_col,
         line=split.lhs + split.rhs,
         line_before=split.lhs,

--- a/coq/server/trans.py
+++ b/coq/server/trans.py
@@ -128,7 +128,7 @@ def trans(
         display_width(s, tabsize=context.tabstop) for s in display.pum.kind_context
     )
     ellipsis_width = display_width(display.pum.ellipsis, tabsize=context.tabstop)
-    truncate = clamp(1, scr_width - context.scr_col, display.pum.x_max_len)
+    truncate = clamp(context.pumwidth, scr_width - context.scr_col, display.pum.x_max_len)
 
     w_adjust = _cum(stack.settings.weights, metrics=metrics)
     sortby = _sort_by(is_lower, adjustment=w_adjust)

--- a/coq/shared/context.py
+++ b/coq/shared/context.py
@@ -25,6 +25,7 @@ EMPTY_CONTEXT = Context(
     comment=("", ""),
     position=(0, 0),
     scr_col=0,
+    pumwidth=1,
     line="",
     line_before="",
     line_after="",

--- a/coq/shared/types.py
+++ b/coq/shared/types.py
@@ -44,6 +44,7 @@ class Context:
     comment: Tuple[str, str]
 
     position: NvimPos
+    pumwidth: int
     scr_col: int
 
     line: str


### PR DESCRIPTION
Avoid making the pum too narrow. Neovim will ensure at least `'pumwidth'` characters are displayed for pum.