### PR TITLE
Improve path completion experience

### DIFF
--- a/coq/server/edit.py
+++ b/coq/server/edit.py
@@ -44,6 +44,7 @@ from ..shared.types import (
     Context,
     ContextualEdit,
     Edit,
+    ExternPath,
     Mark,
     NvimPos,
     RangeEdit,
@@ -491,6 +492,14 @@ def edit(
 
             m_shift = apply(nvim, buf=buf, instructions=instructions)
             if inserted:
+                path_cont = False
+                if (
+                    inserted[0] == "/"
+                    and isinstance(metric.comp.extern, ExternPath) 
+                    and metric.comp.extern.path.is_dir()
+                ):
+                    inserted = inserted[1:]
+                    path_cont = True
                 try:
                     buf_set_text(
                         nvim,
@@ -501,6 +510,9 @@ def edit(
                     )
                 except NvimError as e:
                     log.warn("%s", e)
+                finally:
+                    if path_cont and movement is not None:
+                        n_col -= 1
 
             if movement is not None:
                 try:


### PR DESCRIPTION
If the completed item is a directory and the user pressed a `/` to accept completion, that `/` is not inserted, and completion for subdirectories is triggered as if the trailing `/` from the completion is actually part of the inserted text.