### PR TITLE
✏️ Fix spelling in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ More details at the [PERFORMANCE.md](https://github.com/ms-jpq/coq_nvim/tree/coq
 
 - Real time [performance statistics](https://github.com/ms-jpq/coq_nvim/tree/coq/docs/STATS.md)
 
-- Look at the gifs! The bottom few are the **fastest when I didn't show down on purpose** to show features.
+- Look at the gifs! The bottom few are the **fastest when I didn't slow down on purpose** to show features.
 
 ### Fuzzy Search
 


### PR DESCRIPTION
Even our *typing* is too fast for our own good
Maybe if we didn't **type** so fast, we wouldn't have spelling mistakes