### PR TITLE
Completion ordering by client

### DIFF
--- a/config/defaults.yml
+++ b/config/defaults.yml
@@ -32,7 +32,7 @@ weights:
   recency: 1.0
   proximity: 0.5
 
-ranking: clever
+ranking: uniform
 
 display:
   ghost_text:

--- a/config/defaults.yml
+++ b/config/defaults.yml
@@ -32,6 +32,8 @@ weights:
   recency: 1.0
   proximity: 0.5
 
+ranking: clever
+
 display:
   ghost_text:
     enabled: True

--- a/coq/server/trans.py
+++ b/coq/server/trans.py
@@ -43,7 +43,7 @@ def _sort_by(is_lower: bool, adjustment: Weights, ranking: Ranking) -> Callable[
             for key, val in asdict(metric.weight).items()
         )
 
-    def _tail(metric: Metric) -> Any:
+    def _rest(metric: Metric) -> Any:
         return (
             -len(metric.comp.secondary_edits),
             -(metric.comp.kind != ""),
@@ -54,25 +54,28 @@ def _sort_by(is_lower: bool, adjustment: Weights, ranking: Ranking) -> Callable[
             ),
         )
 
-    def _simple_key_by(metric: Metric) -> Any:
+    # stratified ranking: first sort by weight (proxy for client) and then
+    # by total and the rest
+    def _stratified_key_by(metric: Metric) -> Any:
         return (
             -(metric.comp.preselect),
             -(metric.weight_adjust),
             -round(_tot(metric) * 1000),
-            *_tail(metric)
+            *_rest(metric)
         )
 
-    def _clever_key_by(metric: Metric) -> Any:
+    # uniform ranking (original): sort by weighted total and the rest
+    def _uniform_key_by(metric: Metric) -> Any:
         return (
             -(metric.comp.preselect),
             -round(_tot(metric) * metric.weight_adjust * 1000),
-            *_tail(metric)
+            *_rest(metric)
         )
 
-    if ranking == Ranking.clever:
-        return _clever_key_by
+    if ranking == Ranking.uniform:
+        return _uniform_key_by
     else:
-        return _simple_key_by
+        return _stratified_key_by
 
 
 def _prune(

--- a/coq/shared/settings.py
+++ b/coq/shared/settings.py
@@ -186,8 +186,8 @@ class Clients:
 
 
 class Ranking(Enum):
-    clever = auto()
-    simple = auto()
+    uniform = auto()
+    stratified = auto()
 
 
 @dataclass(frozen=True)

--- a/coq/shared/settings.py
+++ b/coq/shared/settings.py
@@ -185,6 +185,11 @@ class Clients:
     third_party: BaseClient
 
 
+class Ranking(Enum):
+    clever = auto()
+    simple = auto()
+
+
 @dataclass(frozen=True)
 class Settings:
     auto_start: Union[bool, Literal["shut-up"]]
@@ -196,3 +201,4 @@ class Settings:
     completion: CompleteOptions
     keymap: KeyMapping
     clients: Clients
+    ranking: Ranking


### PR DESCRIPTION
Hey!

This PR introduces an alternative way to order the completion results. This idea was already suggested by @elkowar in #92 and by me in #241. I've read the discussion in #92 and while I agree with you that giving unconditional preference to some clients is, generally speaking, not a good idea, I find that for the languages I personally use LSPs give me good enough suggestions that I would love to see them on top all the time. I've tried to play with the client weights, but no matter what I do I cannot achieve this.

This PR implements this unconditional client-based ranking approach -- aliased in the code as `stratified` -- as an alternative to the current one -- aliased as `uniform`. With `stratified` approach we first sort the completion results by client (using `weight_adjust` as the client priority) and then withing the client using all the metrics used before. The choice of a specific ranking strategy is determined by a new settings parameter `ranking`.

The implementation at the moment is a bit ad hoc and it can be properly generalized in future. Also, there are neither documentation nor tests for that change, but I will be happy to add them in case you decide to accept the PR.