### PR TITLE
Set a default for a missing 'pattern' key

### DIFF
--- a/coq/tags/parse.py
+++ b/coq/tags/parse.py
@@ -73,7 +73,7 @@ def parse(mtimes: Mapping[str, float], raw: str) -> Tags:
             else:
                 if json["_type"] == "tag":
                     path = json["path"]
-                    json["pattern"] = _unescape(json["pattern"])
+                    json["pattern"] = _unescape(json.get("pattern", ""))
                     _, _, acc = tags.setdefault(
                         path, (json["language"], mtimes.get(path, 0), [])
                     )


### PR DESCRIPTION
This at least puts a plaster or band-aid over #444 by using get to set a default for a missing pattern.

Now it could be that this covers up a more serious problem, since I haven't yet looked at why the pattern key is missing, or what implications that might have.
