### PR TITLE
venv: Detect python symlink on Nix systems and fix it

### DIFF
--- a/coq/__main__.py
+++ b/coq/__main__.py
@@ -83,6 +83,14 @@ if command == "deps":
                 symlinks=not IS_WIN,
                 clear=True,
             ).create(_RT_DIR)
+            # Detect if python executable is a symlink to /nix/store, and fix it
+            pythonPath = _RT_DIR / "bin" / "python{0.major}.{0.minor}".format(version_info)
+            if "/nix/store" in str(pythonPath.resolve(strict=True)):
+                print("/nix/store path detected! Fixing symlink..")
+                from shutil import which
+                from os import remove
+                remove(pythonPath)
+                pythonPath.symlink_to(which(pythonPath.name))
     except (ImportError, CalledProcessError):
         msg = "Please install python3-venv separately. (apt, yum, apk, etc)"
         io_out.seek(0)

--- a/coq/ci/load.py
+++ b/coq/ci/load.py
@@ -17,7 +17,7 @@ from ..shared.context import EMPTY_CONTEXT
 from ..shared.types import SnippetEdit
 from ..snippets.loaders.load import LoadedSnips
 from ..snippets.loaders.load import load_ci as load_from_paths
-from ..snippets.parse import parse_norm
+from ..snippets.parse import parse_basic
 from ..snippets.parsers.parser import ParseError
 from ..snippets.parsers.types import ParseInfo
 from ..snippets.types import ParsedSnippet
@@ -93,9 +93,10 @@ async def load_parsable() -> Any:
                 grammar=snip.grammar,
             )
             with suppress(ParseError):
-                parse_norm(
+                parse_basic(
                     set(),
                     replace_prefix_threshold=0,
+                    adjust_indent=False,
                     context=EMPTY_CONTEXT,
                     snippet=edit,
                     info=ParseInfo(visual="", clipboard="", comment_str=("", "")),

--- a/coq/clients/buffers/worker.py
+++ b/coq/clients/buffers/worker.py
@@ -84,6 +84,7 @@ class Worker(BaseWorker[BuffersClient, BDB]):
                     label=edit.new_text,
                     sort_by=word.text,
                     primary_edit=edit,
+                    adjust_indent=False,
                     doc=_doc(self._options, context=context, word=word),
                     icon_match="Text",
                 )

--- a/coq/clients/paths/worker.py
+++ b/coq/clients/paths/worker.py
@@ -255,6 +255,7 @@ class Worker(BaseWorker[PathsClient, None]):
                                 new_text=new_text,
                             ),
                             primary_edit=edit,
+                            adjust_indent=False,
                             extern=ExternPath(is_dir=is_dir, path=path),
                             icon_match="Folder" if new_text.endswith(sep) else "File",
                         )

--- a/coq/clients/snippet/worker.py
+++ b/coq/clients/snippet/worker.py
@@ -33,6 +33,7 @@ class Worker(BaseWorker[SnippetClient, SDB]):
                     always_on_top=self._options.always_on_top,
                     weight_adjust=self._options.weight_adjust,
                     primary_edit=edit,
+                    adjust_indent=True,
                     sort_by=snip["word"],
                     label=label,
                     doc=doc,

--- a/coq/clients/t9/worker.py
+++ b/coq/clients/t9/worker.py
@@ -82,6 +82,7 @@ def _decode(client: T9Client, reply: Response) -> Iterator[Completion]:
                     label=label,
                     sort_by=edit.new_text,
                     primary_edit=edit,
+                    adjust_indent=False,
                     kind=kind or "",
                     icon_match=kind,
                 )

--- a/coq/clients/tags/worker.py
+++ b/coq/clients/tags/worker.py
@@ -185,6 +185,7 @@ class Worker(BaseWorker[TagsClient, CTDB]):
                         label=edit.new_text,
                         sort_by=name,
                         primary_edit=edit,
+                        adjust_indent=False,
                         kind=kind,
                         doc=_doc(self._options, context=context, tag=tag),
                         icon_match=kind,

--- a/coq/clients/tmux/worker.py
+++ b/coq/clients/tmux/worker.py
@@ -59,6 +59,7 @@ class Worker(BaseWorker[TmuxClient, TMDB]):
                     label=edit.new_text,
                     sort_by=word.text,
                     primary_edit=edit,
+                    adjust_indent=False,
                     doc=_doc(self._options, word=word),
                     icon_match="Text",
                 )

--- a/coq/clients/tree_sitter/worker.py
+++ b/coq/clients/tree_sitter/worker.py
@@ -65,6 +65,7 @@ def _trans(client: TSClient, context: Context, payload: Payload) -> Completion:
         label=edit.new_text,
         sort_by=payload.text,
         primary_edit=edit,
+        adjust_indent=False,
         kind=payload.kind,
         doc=_doc(client, context=context, payload=payload),
         icon_match=icon_match,

--- a/coq/server/registrants/options.py
+++ b/coq/server/registrants/options.py
@@ -71,8 +71,7 @@ def set_options(nvim: Nvim, mapping: KeyMapping, fast_close: bool) -> None:
             << "pumvisible() ? '<c-e><c-x><c-u>' : '<c-x><c-u>'"
         )
         if not mapping.manual_complete_insertion_only:
-            keymap.nv(mapping.manual_complete) << r"<c-\><c-n>i<c-x><c-u>"
-
+            _ = keymap.nv(mapping.manual_complete) << r"<c-\><c-n>i<c-x><c-u>"
 
     settings["completeopt"] += (
         "noinsert",

--- a/coq/server/registrants/preview.py
+++ b/coq/server/registrants/preview.py
@@ -293,6 +293,7 @@ def _resolve_comp(
                         label="",
                         sort_by="",
                         primary_edit=Edit(new_text=""),
+                        adjust_indent=False,
                         doc=doc,
                         icon_match=None,
                     )

--- a/coq/server/registrants/snippets.py
+++ b/coq/server/registrants/snippets.py
@@ -44,7 +44,7 @@ from ...shared.timeit import timeit
 from ...shared.types import Edit, Mark, SnippetEdit, SnippetGrammar
 from ...snippets.loaders.load import load_direct
 from ...snippets.loaders.neosnippet import load_neosnippet
-from ...snippets.parse import parse_norm
+from ...snippets.parse import parse_basic
 from ...snippets.parsers.types import ParseInfo
 from ...snippets.types import SCHEMA, LoadedSnips, ParsedSnippet
 from ..rt_types import Stack
@@ -199,9 +199,10 @@ def _trans(
 ) -> Iterator[Tuple[ParsedSnippet, Edit, Sequence[Mark]]]:
     for snip in snips:
         edit = SnippetEdit(grammar=snip.grammar, new_text=snip.content)
-        parsed, marks = parse_norm(
+        parsed, marks = parse_basic(
             unifying_chars,
             replace_prefix_threshold=replace_prefix_threshold,
+            adjust_indent=False,
             context=EMPTY_CONTEXT,
             snippet=edit,
             info=info,

--- a/coq/server/state.py
+++ b/coq/server/state.py
@@ -55,6 +55,7 @@ _state = State(
         comp=Completion(
             source="",
             primary_edit=Edit(new_text=""),
+            adjust_indent=False,
             always_on_top=False,
             weight_adjust=0,
             label="",

--- a/coq/shared/trans.py
+++ b/coq/shared/trans.py
@@ -1,4 +1,5 @@
-from typing import AbstractSet, Iterator
+from itertools import chain, repeat
+from typing import AbstractSet, Iterable, Iterator
 
 from .context import cword_after, cword_before
 from .parse import coalesce, lower
@@ -115,7 +116,7 @@ def expand_tabs(context: Context, text: str) -> str:
     return new_text
 
 
-def indent_to_line(context: Context, line_before: str) -> str:
+def _indent_to_line(context: Context, line_before: str) -> str:
     indent_len = len(line_before)
     indent = (
         " " * indent_len
@@ -123,3 +124,12 @@ def indent_to_line(context: Context, line_before: str) -> str:
         else (" " * indent_len).replace(" " * context.tabstop, "\t")
     )
     return indent
+
+
+def indent_adjusted(
+    context: Context, line_before: str, lines: Iterable[str]
+) -> Iterator[str]:
+    indent = _indent_to_line(context, line_before=line_before)
+    expanded = (expand_tabs(context, text=line) for line in lines)
+    for lhs, rhs in zip(chain(("",), repeat(indent)), expanded):
+        yield lhs + rhs

--- a/coq/shared/types.py
+++ b/coq/shared/types.py
@@ -161,6 +161,7 @@ class Completion:
     label: str
     sort_by: str
     primary_edit: Edit
+    adjust_indent: bool
     icon_match: Optional[str]
 
     uid: UUID = field(default_factory=uuid4)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 std2@https://github.com/ms-jpq/std2/archive/64aa5eed6201051e192f97ae961e097bea526cbf.tar.gz
-pynvim_pp@https://github.com/ms-jpq/pynvim_pp/archive/a0f9090fbcadccccd58a0625d6cf1e5dd701b206.tar.gz
+pynvim_pp@https://github.com/ms-jpq/pynvim_pp/archive/f9e61ac71b89c1c2d4676839e614647d59a65034.tar.gz
 pynvim==0.4.3
 PyYAML==5.4.1

--- a/tests/snippets/parse.py
+++ b/tests/snippets/parse.py
@@ -8,7 +8,7 @@ from unittest import TestCase
 from ...coq.ci.load import load
 from ...coq.shared.context import EMPTY_CONTEXT
 from ...coq.shared.types import SnippetEdit
-from ...coq.snippets.parse import parse_norm
+from ...coq.snippets.parse import parse_basic
 from ...coq.snippets.parsers.types import ParseError, ParseInfo
 
 _THRESHOLD = 0.95
@@ -28,9 +28,10 @@ class Parser(TestCase):
         def errs() -> Iterator[Exception]:
             for edit in edits:
                 try:
-                    parse_norm(
+                    parse_basic(
                         set(),
                         replace_prefix_threshold=0,
+                        adjust_indent=False,
                         context=EMPTY_CONTEXT,
                         snippet=edit,
                         info=ParseInfo(visual="", clipboard="", comment_str=("", "")),


### PR DESCRIPTION
On systems using Python installed via Nix, when creating a venv, an expendable symlink is created pointing to something like: `/nix/store/xxxxxxxxxxxxxxxxxx-python3-3.10.6/bin/python3.10` which might get deleted if the system is upgraded. Detect such symlink, and use the 1st `python` found in `$PATH` instead as the symlink, similarly to:

https://github.com/glacambre/firenvim/blob/56a49d79904921a8b4405786e12b4e12fbbf171b/autoload/firenvim.vim#L529
