### PR TITLE
Let Nvim assign random port for serverstart

### DIFF
--- a/lua/coq.lua
+++ b/lua/coq.lua
@@ -116,8 +116,7 @@ local set_coq_call = function(cmd)
   coq[cmd] = function(...)
     local args = {...}
 
-    local srv = is_win and {"localhost:0"} or {}
-    local server = vim.fn.serverstart(unpack(srv))
+    local server = vim.fn.serverstart("localhost:0")
 
     if not job_id then
       job_id =


### PR DESCRIPTION
I've been having the attached problem since upgrading to Neovim 0.8.0 (nightly when it was happening and now stable), but by letting the `serverstart` function always assign the port everything functions as expected so far as I can tell. 
This problem also exists on ChadTree
Tested on macOS Monterey 12.6
It seems like a pretty harmless switch, but let me know if I overlooked a reason for the initial implementation

![Screen Shot 2022-11-27 at 3 15 38 PM](https://user-images.githubusercontent.com/40901109/204160195-307fc54c-472c-4b84-8c4e-e70b4fa72d3a.png)