### PR TITLE
Add setting to enable/disable displaying preview

### DIFF
--- a/config/defaults.yml
+++ b/config/defaults.yml
@@ -62,6 +62,7 @@ display:
       - "」"
 
   preview:
+    enabled: true
     x_max_len: 88
     resolve_timeout: 0.09
     border: rounded

--- a/coq/server/registrants/preview.py
+++ b/coq/server/registrants/preview.py
@@ -195,23 +195,24 @@ async def _set_win(display: PreviewDisplay, buf: Buffer, pos: _Pos) -> None:
 
 
 async def _show_preview(stack: Stack, event: _Event, doc: Doc, s: State) -> None:
-    new_doc = _preprocess(s.context, doc=doc)
-    text = expand_tabs(s.context, text=new_doc.text)
-    lines = text.splitlines()
-    pit = _positions(stack.settings.display.preview, event=event, lines=lines, state=s)
+    if stack.settings.display.preview.enabled:
+        new_doc = _preprocess(s.context, doc=doc)
+        text = expand_tabs(s.context, text=new_doc.text)
+        lines = text.splitlines()
+        pit = _positions(stack.settings.display.preview, event=event, lines=lines, state=s)
 
-    def key(k: Tuple[int, int, _Pos]) -> Tuple[int, int, int, int]:
-        idx, rank, pos = k
-        return pos.height * pos.width, idx == s.pum_location, -rank, -idx
+        def key(k: Tuple[int, int, _Pos]) -> Tuple[int, int, int, int]:
+            idx, rank, pos = k
+            return pos.height * pos.width, idx == s.pum_location, -rank, -idx
 
-    if ordered := sorted(pit, key=key, reverse=True):
-        (pum_location, _, pos), *__ = ordered
-        state(pum_location=pum_location)
-        buf = await Buffer.create(
-            listed=False, scratch=True, wipe=True, nofile=True, noswap=True
-        )
-        await buf_set_preview(buf=buf, syntax=new_doc.syntax, preview=lines)
-        await _set_win(display=stack.settings.display.preview, buf=buf, pos=pos)
+        if ordered := sorted(pit, key=key, reverse=True):
+            (pum_location, _, pos), *__ = ordered
+            state(pum_location=pum_location)
+            buf = await Buffer.create(
+                listed=False, scratch=True, wipe=True, nofile=True, noswap=True
+            )
+            await buf_set_preview(buf=buf, syntax=new_doc.syntax, preview=lines)
+            await _set_win(display=stack.settings.display.preview, buf=buf, pos=pos)
 
 
 async def _resolve_comp(

--- a/coq/shared/settings.py
+++ b/coq/shared/settings.py
@@ -49,6 +49,7 @@ class PreviewPositions:
 
 @dataclass(frozen=True)
 class PreviewDisplay:
+    enabled: bool
     x_max_len: int
     positions: PreviewPositions
     border: Border

--- a/docs/DISPLAY.md
+++ b/docs/DISPLAY.md
@@ -138,6 +138,14 @@ For item `<source>` show `「<source>」`, purely for aesthetics.
 
 Used for the preview window.
 
+##### `coq_settings.display.preview.enabled`
+
+**default:**
+
+```json
+true
+```
+
 ##### `coq_settings.display.preview.x_max_len`
 
 Maximum width.


### PR DESCRIPTION
This change adds a new setting to disable the preview feature in coq. This can be used to reduce visual clutter or the user is using a different plugin for signature previews and the like.

Let me know if there are any ways you would like me to improve this PR. I have only played around in this codebase for the past hour, so I could have easily overlooked something important making this change.