### PR TITLE
Fix missing error message when python3-venv is not installed

### DIFF
--- a/coq/__main__.py
+++ b/coq/__main__.py
@@ -97,8 +97,8 @@ if command == "deps":
                 symlinks=not IS_WIN,
                 clear=True,
             ).create(_RT_DIR)
-    except (ImportError, CalledProcessError):
-        msg = "Please install python3-venv separately. (apt, yum, apk, etc)"
+    except (ImportError, CalledProcessError, SystemExit):
+        msg = "Please install python3-venv separately. (apt, yum, apk, etc)\n"
         print(msg, io_out.getvalue(), file=stderr)
         exit(1)
     else:


### PR DESCRIPTION
When I ran `:COQdeps`, the only message I received was `...`. It appears that `EnvBuilder.create()` was causing a `SystemExit` that bypassed the `except` statement that would inform me of the problem.

Catching `SystemExit` here allows the error message to display. I also added a newline to separate `msg` from the output of `EnvBuilder`.