### PR TITLE
Import `Mapping` from `typing` instead of `collections.abs`

### DIFF
--- a/coq/clients/registers/worker.py
+++ b/coq/clients/registers/worker.py
@@ -1,6 +1,5 @@
 from asyncio import create_task
-from collections.abc import Mapping
-from typing import AbstractSet, AsyncIterator, MutableSet
+from typing import AbstractSet, AsyncIterator, MutableSet, Mapping
 
 from pynvim_pp.atomic import Atomic
 from pynvim_pp.logging import suppress_and_log


### PR DESCRIPTION
Fixes https://github.com/ms-jpq/coq_nvim/issues/585

I saw the same error as @niiichtsy described in the issue. Not sure about the root causes, but I decided to turn the solution described in the issue to a PR