### PR TITLE
Fix venv check

### DIFF
--- a/coq/__main__.py
+++ b/coq/__main__.py
@@ -78,7 +78,7 @@ _EXEC_PATH = Path(executable)
 _EXEC_PATH = _EXEC_PATH.parent.resolve(strict=True) / _EXEC_PATH.name
 _REQ = REQUIREMENTS.read_text()
 
-_IN_VENV = _RT_PY == _EXEC_PATH
+_IN_VENV = _RT_PY.parent.resolve(strict=True) / _RT_PY.name == _EXEC_PATH
 
 
 if command == "deps":


### PR DESCRIPTION
If the venv path is a symlink somewhere along the way, the comparison to the executable path can fail (e.g. if `XDG_DATA_HOME`/`vim.fn.stdpath("data")` is a symlink to another directory). Resolve the `_RT_PY` path the same way `_EXEC_PATH` is resolved so the comparison is valid