### PR TITLE
Fix tmux pane info parsing

### DIFF
--- a/coq/tmux/parse.py
+++ b/coq/tmux/parse.py
@@ -10,7 +10,7 @@ from std2.asyncio.subprocess import call
 
 from ..shared.executor import very_nice
 
-_SEP = "\x1f"
+_SEP = "\t"
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
In tmux versions >3.3a (e.g. `tmux next-3.4`), the ascii unit separator character `\x1f` in the format string is no longer being printed as a raw byte but is now escaped (`tmux display -p $'#{window_id}\x1f#{window_name}'` gets printed as literally `@0\037zsh`).

Use a tab character as the delimiter instead of the unit separator. This should be fine because tmux will not allow tab characters in session/window/pane name anyways.

see: https://github.com/tmux/tmux/issues/3451

fixes #544