### PR TITLE
Add settings.display.mark_applied_notify option

### DIFF
--- a/config/defaults.yml
+++ b/config/defaults.yml
@@ -148,6 +148,7 @@ display:
     spacing: 1
 
   mark_highlight_group: Pmenu
+  mark_applied_notify: True
 
   preview:
     border: rounded

--- a/coq/server/registrants/marks.py
+++ b/coq/server/registrants/marks.py
@@ -83,6 +83,7 @@ def _safexform(xform: Optional[TextTransform], text: str) -> str:
 
 
 async def _single_mark(
+    mark_applied_notify: bool,
     st: State,
     mark: ExtMark,
     marks: Sequence[ExtMark],
@@ -130,7 +131,7 @@ async def _single_mark(
     else:
         await Nvim.exec("startinsert")
         state(inserted_pos=(row, col))
-        if not picked:
+        if not picked and mark_applied_notify:
             msg = LANG("applied mark", marks_left=len(marks))
             await Nvim.write(msg)
     finally:
@@ -188,7 +189,9 @@ async def nav_mark(stack: Stack) -> None:
         mark = marks.popleft()
 
         async def single() -> None:
-            await _single_mark(s, mark=mark, marks=marks, ns=ns, win=win, buf=buf)
+            mark_applied_notify = stack.settings.display.mark_applied_notify
+            await _single_mark(mark_applied_notify, s,
+                               mark=mark, marks=marks, ns=ns, win=win, buf=buf)
 
         if linked := tuple(m for m in marks if m.marker == mark.marker):
             edited = await _linked_marks(

--- a/coq/shared/settings.py
+++ b/coq/shared/settings.py
@@ -83,6 +83,7 @@ class Display:
     icons: Icons
     time_fmt: str
     mark_highlight_group: str
+    mark_applied_notify: bool
     statusline: Statusline
 
 

--- a/docs/DISPLAY.md
+++ b/docs/DISPLAY.md
@@ -14,6 +14,18 @@ The highlight group alias for snippet regions that you can navigate around using
 
 ---
 
+#### `coq_settings.display.mark_applied_notify`
+
+When you go the next edit region (e.g : snippet placeholder) you are notified when a mark is applied if this option is enabled.
+
+**default:**
+
+```json
+true
+```
+
+---
+
 #### coq_settings.display.ghost_text
 
 The virtual text previewing selected completion
@@ -57,7 +69,7 @@ Disabling this will lead to more smooth menu animation, but also the stale resul
 **default:**
 
 ```json
-True
+true
 ```
 
 ##### `coq_settings.display.pum.y_max_len`


### PR DESCRIPTION
Hello,
I do not like that every time I <c-h> to go to the next placeholder there is a notification saying mark applied. I do not think it's useful and I think it slows me down. Therefore I added an option to disable it.
I set the new default to have the same behaviour as right now (notify).
