### PR TITLE
Fix race condition in LSP (and 3P) requests

### DIFF
--- a/coq/lsp/requests/request.py
+++ b/coq/lsp/requests/request.py
@@ -129,9 +129,8 @@ async def _lsp_notify(stack: Stack, rpayload: _Payload) -> None:
             session = _Session(uid=payload.uid, done=payload.done, acc=acc)
             with _LOCK:
                 _STATE[payload.name] = session
-
-        producer.set()
-        await consumer.wait()
+            producer.set()
+            await consumer.wait()
 
     if get_running_loop() == origin:
         await cont()

--- a/coq/lsp/requests/request.py
+++ b/coq/lsp/requests/request.py
@@ -77,9 +77,9 @@ def _uids(_: str) -> Iterator[int]:
 
 
 @lru_cache(maxsize=None)
-def _events(_: str) -> Tuple[AbstractEventLoop, Event, Event]:
+def _events(_: str) -> Tuple[AbstractEventLoop, Event]:
     loop = get_running_loop()
-    return (loop, Event(), Event())
+    return (loop, Event())
 
 
 async def _lsp_pull(
@@ -107,7 +107,7 @@ async def _lsp_pull(
 @rpc(blocking=False)
 async def _lsp_notify(stack: Stack, rpayload: _Payload) -> None:
     payload = _DECODER(rpayload)
-    origin, consumer, producer = _events(payload.name)
+    origin, producer = _events(payload.name)
 
     async def cont() -> None:
         producer.clear()
@@ -129,8 +129,7 @@ async def _lsp_notify(stack: Stack, rpayload: _Payload) -> None:
             session = _Session(uid=payload.uid, done=payload.done, acc=acc)
             with _LOCK:
                 _STATE[payload.name] = session
-            producer.set()
-            await consumer.wait()
+        producer.set()
 
     if get_running_loop() == origin:
         await cont()
@@ -143,7 +142,7 @@ async def async_request(
     name: str, multipart: Optional[int], clients: AbstractSet[str], *args: Any
 ) -> AsyncIterator[_Client]:
     with timeit(f"LSP :: {name}"):
-        (_, consumer, producer), uid = _events(name), next(_uids(name))
+        (_, producer), uid = _events(name), next(_uids(name))
 
         with _LOCK:
             _STATE[name] = _Session(uid=uid, done=False, acc=[])
@@ -156,7 +155,6 @@ async def async_request(
         )
 
         while True:
-            consumer.clear()
             with _LOCK:
                 state = _STATE.get(name)
 
@@ -188,5 +186,5 @@ async def async_request(
                         "%s", f"<><> DELAYED LSP RESP <><> :: {name} {state.uid} {uid}"
                     )
 
-            consumer.set()
             await producer.wait()
+            producer.clear()

--- a/coq/lsp/requests/request.py
+++ b/coq/lsp/requests/request.py
@@ -1,6 +1,6 @@
 from asyncio import (
     AbstractEventLoop,
-    Condition,
+    Event,
     get_running_loop,
     run_coroutine_threadsafe,
     sleep,
@@ -77,9 +77,9 @@ def _uids(_: str) -> Iterator[int]:
 
 
 @lru_cache(maxsize=None)
-def _conds(_: str) -> Tuple[AbstractEventLoop, Condition]:
+def _events(_: str) -> Tuple[AbstractEventLoop, Event, Event]:
     loop = get_running_loop()
-    return (loop, Condition())
+    return (loop, Event(), Event())
 
 
 async def _lsp_pull(
@@ -107,9 +107,10 @@ async def _lsp_pull(
 @rpc(blocking=False)
 async def _lsp_notify(stack: Stack, rpayload: _Payload) -> None:
     payload = _DECODER(rpayload)
-    origin, cond = _conds(payload.name)
+    origin, consumer, producer = _events(payload.name)
 
     async def cont() -> None:
+        producer.clear()
         with _LOCK:
             state = _STATE.get(payload.name)
 
@@ -129,8 +130,8 @@ async def _lsp_notify(stack: Stack, rpayload: _Payload) -> None:
             with _LOCK:
                 _STATE[payload.name] = session
 
-        async with cond:
-            cond.notify_all()
+        producer.set()
+        await consumer.wait()
 
     if get_running_loop() == origin:
         await cont()
@@ -143,14 +144,12 @@ async def async_request(
     name: str, multipart: Optional[int], clients: AbstractSet[str], *args: Any
 ) -> AsyncIterator[_Client]:
     with timeit(f"LSP :: {name}"):
-        (_, cond), uid = _conds(name), next(_uids(name))
+        (_, consumer, producer), uid = _events(name), next(_uids(name))
 
         with _LOCK:
             _STATE[name] = _Session(uid=uid, done=False, acc=[])
 
-        async with cond:
-            cond.notify_all()
-
+        producer.clear()
         await Nvim.api.exec_lua(
             NoneType,
             f"{NAMESPACE}.{name}(...)",
@@ -158,6 +157,7 @@ async def async_request(
         )
 
         while True:
+            consumer.clear()
             with _LOCK:
                 state = _STATE.get(name)
 
@@ -189,5 +189,5 @@ async def async_request(
                         "%s", f"<><> DELAYED LSP RESP <><> :: {name} {state.uid} {uid}"
                     )
 
-            async with cond:
-                await cond.wait()
+            consumer.set()
+            await producer.wait()


### PR DESCRIPTION
This fixes the race condition described in #632 and makes `coq` feel more responsive in some situations (since it doesn't need to wait for a timeout). I know that you don't checkout notifications/issues very much, so I would really appreciate you talking a look at this small PR @ms-jpq.

Thanks in advande :D