### PR TITLE
docs: adding Lua's equivalent code to some Vimscript's

### DIFF
--- a/docs/CONF.md
+++ b/docs/CONF.md
@@ -11,7 +11,7 @@ let g:coq_settings = { ... }
 Lua:
 
 ```lua
-local vim.g.coq_settings = { ... }
+vim.g.coq_settings = { ... }
 ```
 
 ---

--- a/docs/CONF.md
+++ b/docs/CONF.md
@@ -51,8 +51,20 @@ Variables will be validated against a schema.
 
 ie.
 
+Vim:
+
 ```vim
 let g:coq_settings = { 'match.look_ahead': 'dog' }
+```
+
+Lua:
+
+```lua
+vim.g.coq_settings = {
+    match = {
+        look_ahead = "dog",
+    },
+}
 ```
 
 Will give you the following error message:

--- a/docs/KEYBIND.md
+++ b/docs/KEYBIND.md
@@ -129,4 +129,22 @@ ino <silent><expr> <BS>    pumvisible() ? "\<C-e><BS>"  : "\<BS>"
 ino <silent><expr> <CR>    pumvisible() ? (complete_info().selected == -1 ? "\<C-e><CR>" : "\<C-y>") : "\<CR>"
 ino <silent><expr> <Tab>   pumvisible() ? "\<C-n>" : "\<Tab>"
 ino <silent><expr> <S-Tab> pumvisible() ? "\<C-p>" : "\<BS>"
+
+" For Lua
+vim.g.coq_settings = {
+    keymap = {
+        recommended = false,
+    },
+}
+vim.api.nvim_set_keymap('i', '<Esc>', [[pumvisible() ? "\<C-e><Esc>" : "\<Esc>"]], { expr = true, silent = true })
+vim.api.nvim_set_keymap('i', '<C-c>', [[pumvisible() ? "\<C-e><C-c>" : "\<C-c>"]], { expr = true, silent = true })
+vim.api.nvim_set_keymap('i', '<BS>', [[pumvisible() ? "\<C-e><BS>" : "\<BS>"]], { expr = true, silent = true })
+vim.api.nvim_set_keymap(
+  "i",
+  "<CR>",
+  [[pumvisible() ? (complete_info().selected == -1 ? "\<C-e><CR>" : "\<C-y>") : "\<CR>"]],
+  { expr = true, silent = true }
+)
+vim.api.nvim_set_keymap('i', '<Tab>', [[pumvisible() ? "\<C-n>" : "\<Tab>"]], { expr = true, silent = true })
+vim.api.nvim_set_keymap('i', '<S-Tab>', [[pumvisible() ? "\<C-p>" : "\<BS>"]], { expr = true, silent = true })
 ```

--- a/docs/KEYBIND.md
+++ b/docs/KEYBIND.md
@@ -107,6 +107,7 @@ null
 Map the manual keybinding trigger only in `INSERT` mode.
 
 **default**:
+
 ```json
 false
 ```
@@ -114,7 +115,7 @@ false
 ## Custom keybindings
 
 If you would like to set your own keybindings, add the following to your
-init.vim and edit them to your liking.
+`init.vim` and edit them to your liking.
 
 ```vim
 " 🐓 Coq completion settings
@@ -129,13 +130,21 @@ ino <silent><expr> <BS>    pumvisible() ? "\<C-e><BS>"  : "\<BS>"
 ino <silent><expr> <CR>    pumvisible() ? (complete_info().selected == -1 ? "\<C-e><CR>" : "\<C-y>") : "\<CR>"
 ino <silent><expr> <Tab>   pumvisible() ? "\<C-n>" : "\<Tab>"
 ino <silent><expr> <S-Tab> pumvisible() ? "\<C-p>" : "\<BS>"
+```
 
-" For Lua
+If you're using Neovim, add this to your `init.lua`
+
+```lua
+-- 🐓 Coq completion settings
+
+-- Set recommended to false
 vim.g.coq_settings = {
     keymap = {
         recommended = false,
     },
 }
+
+-- Keybindings
 vim.api.nvim_set_keymap('i', '<Esc>', [[pumvisible() ? "\<C-e><Esc>" : "\<Esc>"]], { expr = true, silent = true })
 vim.api.nvim_set_keymap('i', '<C-c>', [[pumvisible() ? "\<C-e><C-c>" : "\<C-c>"]], { expr = true, silent = true })
 vim.api.nvim_set_keymap('i', '<BS>', [[pumvisible() ? "\<C-e><BS>" : "\<BS>"]], { expr = true, silent = true })


### PR DESCRIPTION
During the process of setting up `coq_nvim`, I noticed a lack of Lua code for configuring this plugin on Neovim.

`coq_nvim` is quite impressive, I've been enjoying it so far. Thank you for putting time and effort into making this plugin really fast.