### PR TITLE
feat(docs): adding code sample for installing COQ with `lazy.nvim`

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,7 +309,8 @@ Neovim with `lazy.nvim`:
   },
   init = function()
     vim.g.coq_settings = {
-        --- Your COQ settings here
+        auto_start = true, -- if you want to start COQ at startup
+        -- Your COQ settings here
     }
   end,
   config = function()

--- a/README.md
+++ b/README.md
@@ -290,7 +290,7 @@ Neovim with `lazy.nvim`:
 ```lua
 {
   "neovim/nvim-lspconfig", -- REQUIRED: for native Neovim LSP integration
-  lazy = false, -- REQUIRED: tell lazy.nvim to start this plugin on startup
+  lazy = false, -- REQUIRED: tell lazy.nvim to start this plugin at startup
   dependencies = {
     -- main one
     { "ms-jpq/coq_nvim", branch = "coq" },

--- a/README.md
+++ b/README.md
@@ -288,7 +288,9 @@ apt install --yes -- python3-venv
 </details>
 
 <details>
-  <summary>Neovim with `lazy.nvim`</summary>
+  <summary>Neovim</summary>
+
+  lazy.nvim:
 
   ```lua
   {

--- a/README.md
+++ b/README.md
@@ -264,60 +264,64 @@ apt install --yes -- python3-venv
 
 **Minimum version**: python:`3.8.2`, nvim: `0.5`, sqlite: `recentish`
 
-Install the usual way, ie. VimPlug, Vundle, etc
+<details>
+  <summary>Vim</summary>
 
-Vim:
+  Install the usual way, ie. VimPlug, Vundle, etc
 
-```VimL
-" main one
-Plug 'ms-jpq/coq_nvim', {'branch': 'coq'}
-" 9000+ Snippets
-Plug 'ms-jpq/coq.artifacts', {'branch': 'artifacts'}
+  ```VimL
+  " main one
+  Plug 'ms-jpq/coq_nvim', {'branch': 'coq'}
+  " 9000+ Snippets
+  Plug 'ms-jpq/coq.artifacts', {'branch': 'artifacts'}
 
-" lua & third party sources -- See https://github.com/ms-jpq/coq.thirdparty
-" Need to **configure separately**
+  " lua & third party sources -- See https://github.com/ms-jpq/coq.thirdparty
+  " Need to **configure separately**
 
-Plug 'ms-jpq/coq.thirdparty', {'branch': '3p'}
-" - shell repl
-" - nvim lua api
-" - scientific calculator
-" - comment banner
-" - etc
-```
+  Plug 'ms-jpq/coq.thirdparty', {'branch': '3p'}
+  " - shell repl
+  " - nvim lua api
+  " - scientific calculator
+  " - comment banner
+  " - etc
+  ```
+</details>
 
-Neovim with `lazy.nvim`:
+<details>
+  <summary>Neovim with `lazy.nvim`</summary>
 
-```lua
-{
-  "neovim/nvim-lspconfig", -- REQUIRED: for native Neovim LSP integration
-  lazy = false, -- REQUIRED: tell lazy.nvim to start this plugin at startup
-  dependencies = {
-    -- main one
-    { "ms-jpq/coq_nvim", branch = "coq" },
-
-    -- 9000+ Snippets
-    { "ms-jpq/coq.artifacts", branch = "artifacts" },
-
-    -- lua & third party sources -- See https://github.com/ms-jpq/coq.thirdparty
-    -- Need to **configure separately**
-    { 'ms-jpq/coq.thirdparty', branch = "3p" }
-    -- - shell repl
-    -- - nvim lua api
-    -- - scientific calculator
-    -- - comment banner
-    -- - etc
-  },
-  init = function()
-    vim.g.coq_settings = {
-        auto_start = true, -- if you want to start COQ at startup
-        -- Your COQ settings here
-    }
-  end,
-  config = function()
-    -- Your LSP settings here
-  end,
-}
-```
+  ```lua
+  {
+    "neovim/nvim-lspconfig", -- REQUIRED: for native Neovim LSP integration
+    lazy = false, -- REQUIRED: tell lazy.nvim to start this plugin at startup
+    dependencies = {
+      -- main one
+      { "ms-jpq/coq_nvim", branch = "coq" },
+  
+      -- 9000+ Snippets
+      { "ms-jpq/coq.artifacts", branch = "artifacts" },
+  
+      -- lua & third party sources -- See https://github.com/ms-jpq/coq.thirdparty
+      -- Need to **configure separately**
+      { 'ms-jpq/coq.thirdparty', branch = "3p" }
+      -- - shell repl
+      -- - nvim lua api
+      -- - scientific calculator
+      -- - comment banner
+      -- - etc
+    },
+    init = function()
+      vim.g.coq_settings = {
+          auto_start = true, -- if you want to start COQ at startup
+          -- Your COQ settings here
+      }
+    end,
+    config = function()
+      -- Your LSP settings here
+    end,
+  }
+  ```
+</details>
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -290,7 +290,7 @@ apt install --yes -- python3-venv
 <details>
   <summary>Neovim</summary>
 
-  lazy.nvim:
+  ### lazy.nvim
 
   ```lua
   {

--- a/README.md
+++ b/README.md
@@ -266,6 +266,8 @@ apt install --yes -- python3-venv
 
 Install the usual way, ie. VimPlug, Vundle, etc
 
+Vim:
+
 ```VimL
 " main one
 Plug 'ms-jpq/coq_nvim', {'branch': 'coq'}
@@ -281,6 +283,39 @@ Plug 'ms-jpq/coq.thirdparty', {'branch': '3p'}
 " - scientific calculator
 " - comment banner
 " - etc
+```
+
+Neovim with `lazy.nvim`:
+
+```lua
+{
+  "neovim/nvim-lspconfig", -- REQUIRED: for native Neovim LSP integration
+  lazy = false, -- REQUIRED: tell lazy.nvim to start this plugin on startup
+  dependencies = {
+    -- main one
+    { "ms-jpq/coq_nvim", branch = "coq" },
+
+    -- 9000+ Snippets
+    { "ms-jpq/coq.artifacts", branch = "artifacts" },
+
+    -- lua & third party sources -- See https://github.com/ms-jpq/coq.thirdparty
+    -- Need to **configure separately**
+    { 'ms-jpq/coq.thirdparty', branch = "3p" }
+    -- - shell repl
+    -- - nvim lua api
+    -- - scientific calculator
+    -- - comment banner
+    -- - etc
+  },
+  init = function()
+    vim.g.coq_settings = {
+        --- Your COQ settings here
+    }
+  end,
+  config = function()
+    -- Your LSP settings here
+  end,
+}
 ```
 
 ## Documentation


### PR DESCRIPTION
Some developers were having troubles trying to configure COQ with Neovim, like the ones [here](https://github.com/ms-jpq/coq_nvim/issues/630), especially with the plugin manager `lazy.nvim` which requires a little bit more setup than `packer.nvim` in order to make things work. So I added some instructions to help them. 