### PR TITLE
fix: making autocompletion work properly after dot and other characters

### DIFF
--- a/coq/shared/runtime.py
+++ b/coq/shared/runtime.py
@@ -147,7 +147,11 @@ class Supervisor:
                         for worker in self._workers
                     )
 
-                    _, pending = await wait(tasks, timeout=timeout)
+                    _, pending = await wait(
+                        tasks,
+                        timeout=timeout,
+                        return_when=FIRST_COMPLETED,
+                    )
                     if not acc:
                         for fut in as_completed(pending):
                             await fut


### PR DESCRIPTION
## Description

Some developers were reporting problems with autocompletion. See the following issues: 
- #576
- #596
- #464
- #562

I was having the same problem, but I found a possible solution.
I want to know you guys opinion on it. I am pretty unexperienced with the codebase, but this solutions works as a charm for me.

## Midia

Code written in C++ using `clangd` as LSP server.

Before:
![ezgif-7-b140af2a41](https://github.com/ms-jpq/coq_nvim/assets/75737377/e00a1b65-fb21-4ee1-9465-8d6a5cf2ba84)

After:
![ezgif-7-a51a65c31b](https://github.com/ms-jpq/coq_nvim/assets/75737377/008e89fe-f909-487d-b56d-3289e3ba4471)

_No zoom, sorry!_

## More information

### Neovim

```
NVIM v0.9.5
Build type: Release
LuaJIT 2.1.1702233742
```

```lua
return {
  "neovim/nvim-lspconfig",
  lazy = false,
  dependencies = {
    -- { "ms-jpq/coq_nvim", branch = "coq" },
    { dir = "~/Documentos/Projects/coq_nvim" },
    { "ms-jpq/coq.artifacts", branch = "artifacts" },
  },
  init = function()
    vim.g.coq_settings = {
      auto_start = "shut-up",
      completion = {
        always = true,
        skip_after = { "{", "}", "[", "]", " ", ":" },
        smart = true,
      },
      keymap = {
        recommended = false,
        pre_select = true,
      },
    }
  end,
  config = function()
    local servers = {
      "clangd", -- C / C++
      "rust_analyzer", -- Rust
      "tsserver", -- Typescript / Javascript
      "jdtls", -- Java
      "eslint", -- Typescript / Javascript (Linter)
      "golangci_lint_ls", -- Golang
      "gopls", -- Golang
      "pyright", -- Python
      -- "lua_ls", -- Lua
      "emmet_ls", -- Emmet
      "cssls", -- CSS,
      "dartls", -- Dart / Flutter
    }

    local lspconfig = require("lspconfig")
    local coq = require("coq")

    for _, server in pairs(servers) do
      lspconfig[server].setup(coq.lsp_ensure_capabilities({}))
    end

    vim.api.nvim_set_keymap(
      "i",
      "<tab>",
      [[pumvisible() ? (complete_info().selected == -1 ? "\<C-e><CR>" : "\<C-y>") : "\<CR>"]],
      { expr = true, silent = true }
    )

    local utils = require("hicaro.utils")

    utils.keyset("n", "<C-e>", vim.diagnostic.open_float)
    utils.keyset("n", "[d", vim.diagnostic.goto_prev)
    utils.keyset("n", "]d", vim.diagnostic.goto_next)

    vim.api.nvim_create_autocmd("LspAttach", {
      desc = "LSP actions",
      callback = function(event)
        local opts = { buffer = event.buf }
        utils.keyset("n", "gd", ":vsp<cr> :lua vim.lsp.buf.definition()<CR>", opts)
        utils.keyset("n", "<leader>d", vim.lsp.buf.definition, opts)
        utils.keyset("n", "K", vim.lsp.buf.hover, opts)
        utils.keyset("n", "<leader>r", vim.lsp.buf.rename, opts)
        utils.keyset({ "n", "v" }, "<leader>lca", vim.lsp.buf.code_action, opts)
      end,
    })
  end,
}

```