### PR TITLE
Not showing preview window if there is nothing in docs.

### DIFF
--- a/coq/server/registrants/preview.py
+++ b/coq/server/registrants/preview.py
@@ -195,26 +195,27 @@ async def _set_win(display: PreviewDisplay, buf: Buffer, pos: _Pos) -> None:
 
 
 async def _show_preview(stack: Stack, event: _Event, doc: Doc, s: State) -> None:
-    if stack.settings.display.preview.enabled:
-        new_doc = _preprocess(s.context, doc=doc)
-        text = expand_tabs(s.context, text=new_doc.text)
-        lines = text.splitlines()
-        pit = _positions(
-            stack.settings.display.preview, event=event, lines=lines, state=s
+    if not stack.settings.display.preview.enabled or not doc.text:
+        return
+    new_doc = _preprocess(s.context, doc=doc)
+    text = expand_tabs(s.context, text=new_doc.text)
+    lines = text.splitlines()
+    pit = _positions(
+        stack.settings.display.preview, event=event, lines=lines, state=s
+    )
+
+    def key(k: Tuple[int, int, _Pos]) -> Tuple[int, int, int, int]:
+        idx, rank, pos = k
+        return pos.height * pos.width, idx == s.pum_location, -rank, -idx
+
+    if ordered := sorted(pit, key=key, reverse=True):
+        (pum_location, _, pos), *__ = ordered
+        state(pum_location=pum_location)
+        buf = await Buffer.create(
+            listed=False, scratch=True, wipe=True, nofile=True, noswap=True
         )
-
-        def key(k: Tuple[int, int, _Pos]) -> Tuple[int, int, int, int]:
-            idx, rank, pos = k
-            return pos.height * pos.width, idx == s.pum_location, -rank, -idx
-
-        if ordered := sorted(pit, key=key, reverse=True):
-            (pum_location, _, pos), *__ = ordered
-            state(pum_location=pum_location)
-            buf = await Buffer.create(
-                listed=False, scratch=True, wipe=True, nofile=True, noswap=True
-            )
-            await buf_set_preview(buf=buf, syntax=new_doc.syntax, preview=lines)
-            await _set_win(display=stack.settings.display.preview, buf=buf, pos=pos)
+        await buf_set_preview(buf=buf, syntax=new_doc.syntax, preview=lines)
+        await _set_win(display=stack.settings.display.preview, buf=buf, pos=pos)
 
 
 async def _resolve_comp(


### PR DESCRIPTION
The preview window will still pop up even there is nothing to preview, and got placed in the status column which is quite strange.

![image](https://github.com/user-attachments/assets/83b7d32e-051d-4f9c-88de-67a9d5ee7728)

And sometimes it just won't disappear even though the completion menu is closed. Maybe this is because the empty preview got placed in the wrong position and therefore might not be closed correctly
![image](https://github.com/user-attachments/assets/4e629e22-58ea-4e17-a4f6-7456e32d6db3)

So I did a little modification to prevent showing the empty preview window and a little style optimization if you don't mind.