### PR TITLE
fix no parser for 'typescriptreact' language

### DIFF
--- a/lua/coq/ts-request.lua
+++ b/lua/coq/ts-request.lua
@@ -2,7 +2,8 @@
   COQ.treesitter_start = function(buf, syntax)
     vim.validate {buf = {buf, "number"}, syntax = {syntax, "string"}}
     if vim.treesitter and vim.treesitter.start then
-      vim.treesitter.start(buf, syntax)
+      local lang = vim.treesitter.language.get_lang(syntax)
+      vim.treesitter.start(buf, lang)
     end
   end
 


### PR DESCRIPTION
While I was trying to use https://github.com/github/copilot.vim, I faced an error when an autocompletion has a preview in it, in which it calls `vim.treesitter` under the hood. This has caused an error due to incorrect language being detected. To fix this, use `vim.treesitter.language.get_lang()` to correctly get treesitter language parser.

Error:
```
(0, 'Error executing lua: /usr/share/nvim/runtime/lua/vim/treesitter/language.lua:107: no parser for \'typescriptreact\' language, see :help treesitter-parsers\nstack traceback:\n\t[C]: in function \'error\'\
n\t/usr/share/nvim/runtime/lua/vim/treesitter/language.lua:107: in function \'add\'\n\t/usr/share/nvim/runtime/lua/vim/treesitter/languagetree.lua:111: in function \'new\'\n\t/usr/share/nvim/runtime/lua/vim/t
reesitter.lua:41: in function \'_create_parser\'\n\t/usr/share/nvim/runtime/lua/vim/treesitter.lua:108: in function \'get_parser\'\n\t/usr/share/nvim/runtime/lua/vim/treesitter.lua:416: in function \'start\'\
n\t...m/site/pack/packer/start/coq_nvim/lua/coq/ts-request.lua:6: in function \'treesitter_start\'\n\t[string "<nvim>"]:1: in main chunk')
Traceback (most recent call last):
  File "/home/terra/.local/share/nvim/site/pack/packer/start/coq_nvim/.vars/runtime/lib/python3.12/site-packages/pynvim_pp/logging.py", line 31, in suppress_and_log
    yield None
  File "/home/terra/.local/share/nvim/site/pack/packer/start/coq_nvim/coq/server/registrants/preview.py", line 267, in cont
    await _show_preview(
  File "/home/terra/.local/share/nvim/site/pack/packer/start/coq_nvim/coq/server/registrants/preview.py", line 207, in _show_preview
    await Nvim.api.exec_lua(
  File "/home/terra/.local/share/nvim/site/pack/packer/start/coq_nvim/.vars/runtime/lib/python3.12/site-packages/pynvim_pp/types.py", line 55, in cont
    resp = await self._rpc.request(method, *params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/terra/.local/share/nvim/site/pack/packer/start/coq_nvim/.vars/runtime/lib/python3.12/site-packages/pynvim_pp/_rpc.py", line 190, in request
    return await wrap_future(f)
           ^^^^^^^^^^^^^^^^^^^^
  File "/home/terra/.local/share/nvim/site/pack/packer/start/coq_nvim/.vars/runtime/lib/python3.12/site-packages/pynvim_pp/_rpc.py", line 187, in cont
    return await wrap_future(fut)
           ^^^^^^^^^^^^^^^^^^^^^^
pynvim_pp.rpc_types.NvimError: (0, 'Error executing lua: /usr/share/nvim/runtime/lua/vim/treesitter/language.lua:107: no parser for \'typescriptreact\' language, see :help treesitter-parsers\nstack traceback:
\n\t[C]: in function \'error\'\n\t/usr/share/nvim/runtime/lua/vim/treesitter/language.lua:107: in function \'add\'\n\t/usr/share/nvim/runtime/lua/vim/treesitter/languagetree.lua:111: in function \'new\'\n\t/u
sr/share/nvim/runtime/lua/vim/treesitter.lua:41: in function \'_create_parser\'\n\t/usr/share/nvim/runtime/lua/vim/treesitter.lua:108: in function \'get_parser\'\n\t/usr/share/nvim/runtime/lua/vim/treesitter.
lua:416: in function \'start\'\n\t...m/site/pack/packer/start/coq_nvim/lua/coq/ts-request.lua:6: in function \'treesitter_start\'\n\t[string "<nvim>"]:1: in main chunk')
```

Before:
![image](https://github.com/user-attachments/assets/2cacc1d9-27b1-4ac6-aeb8-98bdb34ef843)

After:
![image](https://github.com/user-attachments/assets/2a64f370-165c-46cb-a77a-1b2cb2306014)
