### PR TITLE
Adapt to remove deprecated API, tbl_flatten

### DIFF
--- a/lua/coq.lua
+++ b/lua/coq.lua
@@ -72,12 +72,12 @@ end
 local start = function(deps, ...)
   local is_xdg = (vim.g.coq_settings or {}).xdg
   local args =
-    vim.tbl_flatten {
+    vim.iter {
     deps and py3 or main(is_xdg),
     {"-s", "-u", "-m", "coq"},
     {...},
     (is_xdg and {"--xdg", xdg_dir} or {})
-  }
+  }.flatten().totable()
 
   local params = {
     cwd = cwd,


### PR DESCRIPTION
The vim.tbl_flatten API is deprecated and will be removed in Neovim 0.13

`nvim +checkhealth` gives:

```
- WARNING vim.tbl_flatten is deprecated. Feature will be removed in Nvim 0.13                                                                                                                                                                                                                                                                                      
    - ADVICE:                                                                                                                                                                                                                                                                                                                                                        
      - use vim.iter(…):flatten():totable() instead.                                                                                                                                                                                                                                                                                                                 
      - stack traceback:                                                                                                                                                                                                                                                                                                                                             
          $HOME/.local/share/nvim/site/pack/packer/start/coq-nvim/lua/coq.lua:75                                                                                                                                                                                                                                                                             
          $HOME/.local/share/nvim/site/pack/packer/start/coq-nvim/lua/coq.lua:125                                                                                                                                                                                                                                                                            
          $HOME/.local/share/nvim/site/pack/packer/start/coq-nvim/lua/coq.lua:191
```
With this change the deprecation warning goes away.