### PR TITLE
Changed dot -> colon operator

### DIFF
--- a/lua/coq/lsp-request.lua
+++ b/lua/coq/lsp-request.lua
@@ -209,7 +209,7 @@
       return false
     end
 
-    return client.supports_method(lsp_capability or lsp_method)
+    return client:supports_method(lsp_capability or lsp_method)
   end
 
   (function()
@@ -271,7 +271,7 @@
         local request_params = make_params(client)
 
         local go, cancel_handle =
-          client.request(lsp_method, request_params, handler, buf)
+          client:request(lsp_method, request_params, handler, buf)
         if not go then
           handler(
             "<>FAILED<>",
@@ -282,7 +282,7 @@
           table.insert(
             cancels,
             function()
-              client.cancel_request(cancel_handle)
+              client:cancel_request(cancel_handle)
             end
           )
         end


### PR DESCRIPTION
According to vim.deprecated calling:
-     client.supports_method
-     client.request
-     client.cancel_request

is deprecated and will be removed in Nvim 0.13

```
==============================================================================
vim.deprecated:                                                           3 ⚠

 ~
- ⚠ WARNING client.cancel_request is deprecated. Feature will be removed in Nvim 0.13
  - ADVICE:
    - use client:cancel_request instead.
    - stack traceback:
        /home/u009893/.local/share/nvim/site/pack/packer/start/coq-nvim/lua/coq/lsp-request.lua:285
        /home/u009893/.local/share/nvim/site/pack/packer/start/coq-nvim/lua/coq/lsp-request.lua:264
        [C]:-1
        /home/u009893/.local/share/nvim/site/pack/packer/start/coq-nvim/lua/coq/lsp-request.lua:112
        /home/u009893/.local/share/nvim/site/pack/packer/start/coq-nvim/lua/coq/lsp-request.lua:346
        /home/u009893/.local/share/nvim/site/pack/packer/start/coq-nvim/lua/coq/lsp-request.lua:358
        nvim>:1
    - stack traceback:
        /home/u009893/.local/share/nvim/site/pack/packer/start/coq-nvim/lua/coq/lsp-request.lua:285
        /home/u009893/.local/share/nvim/site/pack/packer/start/coq-nvim/lua/coq/lsp-request.lua:264
        [C]:-1
        /home/u009893/.local/share/nvim/site/pack/packer/start/coq-nvim/lua/coq/lsp-request.lua:112
        /home/u009893/.local/share/nvim/site/pack/packer/start/coq-nvim/lua/coq/lsp-request.lua:346
        /home/u009893/.local/share/nvim/site/pack/packer/start/coq-nvim/lua/coq/lsp-request.lua:358
        nvim>:1
        [C]:-1
        lua:1

 ~
- ⚠ WARNING client.request is deprecated. Feature will be removed in Nvim 0.13
  - ADVICE:
    - use client:request instead.
    - stack traceback:
        /home/u009893/.local/share/nvim/site/pack/packer/start/coq-nvim/lua/coq/lsp-request.lua:274
        /home/u009893/.local/share/nvim/site/pack/packer/start/coq-nvim/lua/coq/lsp-request.lua:177
        /home/u009893/.local/share/nvim/site/pack/packer/start/coq-nvim/lua/coq/lsp-request.lua:346
        /home/u009893/.local/share/nvim/site/pack/packer/start/coq-nvim/lua/coq/lsp-request.lua:358
        nvim>:1
        [C]:-1
        lua:1
    - stack traceback:
        /home/u009893/.local/share/nvim/site/pack/packer/start/coq-nvim/lua/coq/lsp-request.lua:274
        /home/u009893/.local/share/nvim/site/pack/packer/start/coq-nvim/lua/coq/lsp-request.lua:177
        /home/u009893/.local/share/nvim/site/pack/packer/start/coq-nvim/lua/coq/lsp-request.lua:346
        /home/u009893/.local/share/nvim/site/pack/packer/start/coq-nvim/lua/coq/lsp-request.lua:358
        nvim>:1

 ~
- ⚠ WARNING client.supports_method is deprecated. Feature will be removed in Nvim 0.13
  - ADVICE:
    - use client:supports_method instead.
    - stack traceback:
        /home/u009893/.local/share/nvim/site/pack/packer/start/coq-nvim/lua/coq/lsp-request.lua:237
        /home/u009893/.local/share/nvim/site/pack/packer/start/coq-nvim/lua/coq/lsp-request.lua:320
        /home/u009893/.local/share/nvim/site/pack/packer/start/coq-nvim/lua/coq/lsp-request.lua:358
        nvim>:1
        [C]:-1
        lua:1
    - stack traceback:
        /home/u009893/.local/share/nvim/site/pack/packer/start/coq-nvim/lua/coq/lsp-request.lua:237
        /home/u009893/.local/share/nvim/site/pack/packer/start/coq-nvim/lua/coq/lsp-request.lua:320
        /home/u009893/.local/share/nvim/site/pack/packer/start/coq-nvim/lua/coq/lsp-request.lua:358
        nvim>:1
```