### PR TITLE
use named instead of positional register parameter

### DIFF
--- a/coq/clients/registers/db/database.py
+++ b/coq/clients/registers/db/database.py
@@ -36,7 +36,7 @@ class RDB(DB):
     def periodical(
         self, wordreg: Mapping[str, str], linereg: Mapping[str, str]
     ) -> None:
-        m1 = (*wordreg, *linereg)
+        m1 = [{"register": r} for r in (*wordreg, *linereg)]
 
         def m2() -> Iterator[Mapping]:
             for reg, text in wordreg.items():


### PR DESCRIPTION
Closes #698

Python 3.14 made it an error to use an iterable when named parameters are in the SQL so use named parameters instead