### PR TITLE
Support Disabling Completion on Blank Line

### DIFF
--- a/coq/server/registrants/omnifunc.py
+++ b/coq/server/registrants/omnifunc.py
@@ -41,6 +41,8 @@ def _should_cont(
             return extern.is_dir
         else:
             return False
+    elif len(cur.line_before) == 0 and "\n" in skip_after:
+        return False
     elif any(cur.line_before.endswith(token) for token in skip_after):
         return False
 


### PR DESCRIPTION
Adding "\n" to `skip_after` now disables completion for blank lines.

Not the most elegant solution but I'm not very experienced with Python syntax and didn't want to break anything.

